### PR TITLE
Bump the mstest-dependencies group with 1 update

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="FluentAssertions" Version="8.3.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="MSTest" Version="3.10.0" />
+    <PackageVersion Include="MSTest" Version="3.10.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
 		<PackageVersion Include="ScriptHookVDotNet3" Version="3.6.0" />
 		<PackageVersion Include="LemonUI.SHVDN3" Version="2.2.0" />


### PR DESCRIPTION
Bumps MSTest from 3.10.0 to 3.10.1

---
updated-dependencies:
- dependency-name: MSTest dependency-version: 3.10.1 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: mstest-dependencies ...