### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/BoBoBaSs84/Los.Santos.Dope.Wars/security/code-scanning/1](https://github.com/BoBoBaSs84/Los.Santos.Dope.Wars/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to restrict the permissions of the GITHUB_TOKEN. Since the workflow only checks out code and runs build/test commands, it does not require write access to repository contents or other resources. The minimal required permission is `contents: read`. You can add the `permissions` block either at the root of the workflow (applies to all jobs) or at the job level. The best practice is to add it at the root level, just below the `name` and before the `on` block, so it applies to all jobs unless overridden. No additional imports or definitions are needed.