### PR TITLE
Update DealMenu.cs

### DIFF
--- a/src/LSDW.Presentation/Menus/DealMenu.cs
+++ b/src/LSDW.Presentation/Menus/DealMenu.cs
@@ -1,15 +1,17 @@
-﻿using LemonUI.Menus;
+#nullable enable
+using System;
+using System.Drawing;
+using System.Linq;
+using LemonUI.Menus;
 using LSDW.Abstractions.Application.Managers;
 using LSDW.Abstractions.Domain.Models;
 using LSDW.Abstractions.Domain.Services;
 using LSDW.Abstractions.Enumerators;
 using LSDW.Abstractions.Extensions;
 using LSDW.Abstractions.Presentation.Menus;
-using LSDW.Domain.Extensions;
 using LSDW.Domain.Factories;
 using LSDW.Presentation.Helpers;
 using LSDW.Presentation.Menus.Base;
-using System.Drawing;
 using GTAFont = GTA.UI.Font;
 
 namespace LSDW.Presentation.Menus;
@@ -19,154 +21,198 @@ namespace LSDW.Presentation.Menus;
 /// </summary>
 internal sealed class DealMenu : MenuBase, IDealMenu
 {
-	private readonly IProviderManager _providerManager;
-	private readonly IPlayer _player;
-	private readonly ITransactionService _transactionService;
-	private readonly IInventory _source;
-	private readonly IInventory _target;
+    private readonly IProviderManager _providerManager;
+    private readonly IPlayer _player;
+    private readonly ITransactionService _transactionService;
+    private readonly IInventory _source;
+    private readonly IInventory _target;
 
-	public TransactionType Type { get; }
-	public event EventHandler? SwitchItemActivated;
+    // Keep strong references to per-item handlers so we can unsubscribe correctly.
+    private readonly System.Collections.Generic.Dictionary<NativeListItem<int>, ItemChangedEventHandler<int>>
+        _itemChangedHandlers = new();
 
-	/// <summary>
-	/// Initializes a instance of the deal menu class.
-	/// </summary>
-	/// <param name="providerManager">The provider manager instance to use.</param>
-	/// <param name="type">The transaction type that defines the menu.</param>
-	/// <param name="player">The player instance to use.</param>
-	/// <param name="inventory">The inventory instance to use.</param>
-	internal DealMenu(IProviderManager providerManager, TransactionType type, IPlayer player, IInventory inventory) : base(type.ToString(), type.GetDescription())
-	{
-		_providerManager = providerManager;
-		Type = type;
-		_player = player;
-		_transactionService = DomainFactory.CreateTransactionService(providerManager, type, _player, inventory);
-		(_source, _target) = MenuHelper.GetInventories(type, player, inventory);
+    public TransactionType Type { get; }
+    public event EventHandler? SwitchItemActivated;
 
-		Alignment = MenuHelper.GetAlignment(type);
-		BannerText.Font = GTAFont.Pricedown;
-		ItemCount = CountVisibility.Never;
-		Offset = GetMenuOffset();
+    /// <summary>
+    /// Initializes a instance of the deal menu class.
+    /// </summary>
+    /// <param name="providerManager">The provider manager instance to use.</param>
+    /// <param name="type">The transaction type that defines the menu.</param>
+    /// <param name="player">The player instance to use.</param>
+    /// <param name="inventory">The inventory instance to use.</param>
+    internal DealMenu(IProviderManager providerManager, TransactionType type, IPlayer player, IInventory inventory)
+        : base(type.ToString(), type.GetDescription())
+    {
+        _providerManager = providerManager;
+        Type = type;
+        _player = player;
+        _transactionService = DomainFactory.CreateTransactionService(providerManager, type, _player, inventory);
+        (_source, _target) = MenuHelper.GetInventories(type, player, inventory);
 
-		AddSwitchItem(type);
-		foreach (IDrug drug in _source)
-			AddDrugListItem(drug, OnItemActivated);
+        Alignment = MenuHelper.GetAlignment(type);
+        BannerText.Font = GTAFont.Pricedown;
+        ItemCount = CountVisibility.Never;
+        Offset = GetMenuOffset();
 
-		MaxItems = Items.Count;
-	}
+        AddSwitchItem(type);
+        foreach (IDrug drug in _source)
+            AddDrugListItem(drug, OnItemActivated);
 
-	private void OnItemActivated(NativeListItem<int> item, EventArgs args)
-	{
-		if (item.Tag is not IDrug drug)
-			return;
+        MaxItems = Items.Count;
+    }
 
-		bool success = _transactionService.Commit(drug.Type, item.SelectedItem, drug.Price);
+    private void OnItemActivated(NativeListItem<int> item, EventArgs args)
+    {
+        if (item.Tag is not IDrug drug)
+            return;
 
-		if (success)
-		{
-			SetDrugListItem(item, drug);
-			_transactionService.BustOrNoBust();
-		}
-	}
+        var quantity = Math.Max(0, item.SelectedItem);
+        if (quantity == 0)
+            return;
 
-	private void OnItemChanged(NativeListItem<int> item)
-		=> SetItemDescription(item);
+        bool success = _transactionService.Commit(drug.Type, quantity, drug.Price);
 
-	private void OnSwitchActivated()
-		=> SwitchItemActivated?.Invoke(this, EventArgs.Empty);
+        if (success)
+        {
+            SetDrugListItem(item, drug);
+            _transactionService.BustOrNoBust();
+        }
+        else
+        {
+            // Show feedback by flashing the description with a warning color prefix.
+            item.Description = $"~r~Transaction failed.~w~\n{item.Description}";
+        }
+    }
 
-	/// <summary>
-	/// Adds a new drug list item to the menu.
-	/// </summary>
-	/// <param name="drug">The drug instance to add.</param>
-	/// <param name="activated">The action to perform when activated.</param>
-	/// <param name="changed">The action to perform when the selected item of the list changes.</param>
-	private void AddDrugListItem(IDrug drug, Action<NativeListItem<int>, EventArgs>? activated = null, Action<NativeListItem<int>, ItemChangedEventArgs<int>>? changed = null)
-	{
-		NativeListItem<int> item = AddListItem(drug.Type.GetName(), string.Empty, activated, changed, drug.Quantity.GetArray());
-		SetDrugListItem(item, drug);
-	}
+    private void OnItemChanged(NativeListItem<int> item) => SetItemDescription(item);
 
-	/// <summary>
-	/// Adds a new menu Switch item to the menu.
-	/// </summary>
-	/// <param name="type">The transaction type that defines the menu.</param>
-	private void AddSwitchItem(TransactionType type) =>
-		AddItem(SwitchItemHelper.GetTitle(type), SwitchItemHelper.GetDescription(type), OnSwitchActivated);
+    private void OnSwitchActivated() => SwitchItemActivated?.Invoke(this, EventArgs.Empty);
 
-	/// <summary>
-	/// Sets all possible things for the <paramref name="item"/> itself.
-	/// </summary>
-	/// <param name="item">The item to refresh.</param>
-	/// <param name="drug">The drug instance to use.</param>
-	private void SetDrugListItem(NativeListItem<int> item, IDrug drug)
-	{
-		item.ItemChanged -= (sender, args) => OnItemChanged(item);
-		item.SelectedIndex = 0;
-		item.Enabled = drug.Quantity > 0;
-		item.Tag = drug;
-		item.Items = drug.Quantity.GetList();
-		item.SelectedIndex = drug.Quantity;
-		item.ItemChanged += (sender, args) => OnItemChanged(item);
-		SetItemDescription(item);
-	}
+    /// <summary>
+    /// Adds a new drug list item to the menu.
+    /// </summary>
+    /// <param name="drug">The drug instance to add.</param>
+    /// <param name="activated">The action to perform when activated.</param>
+    /// <param name="changed">The action to perform when the selected item of the list changes.</param>
+    private void AddDrugListItem(
+        IDrug drug,
+        Action<NativeListItem<int>, EventArgs>? activated = null,
+        Action<NativeListItem<int>, ItemChangedEventArgs<int>>? changed = null)
+    {
+        NativeListItem<int> item = AddListItem(
+            drug.Type.GetName(),
+            string.Empty,
+            activated,
+            changed,
+            drug.Quantity.GetArray());
 
-	/// <summary>
-	/// Sets the item description depending on the information in 
-	/// the <see cref="NativeItem.Tag"/> and the <see cref="TransactionType"/>.
-	/// </summary>
-	/// <param name="item">The item to refresh.</param>
-	private void SetItemDescription(NativeListItem<int> item)
-	{
-		if (item.Tag is not IDrug drug || drug.Quantity.Equals(0))
-			return;
+        SetDrugListItem(item, drug);
+    }
 
-		if (Type is TransactionType.BUY)
-		{
-			int sellingPrice = drug.Price;
-			int averagePrice = drug.Type.GetAveragePrice();
-			int currentQuantitity = item.SelectedItem;
-			int totalPrice = sellingPrice * currentQuantitity;
-			string gbn = GoodBadNetral(sellingPrice, averagePrice);
+    /// <summary>
+    /// Adds a new menu Switch item to the menu.
+    /// </summary>
+    /// <param name="type">The transaction type that defines the menu.</param>
+    private void AddSwitchItem(TransactionType type) =>
+        AddItem(SwitchItemHelper.GetTitle(type), SwitchItemHelper.GetDescription(type), OnSwitchActivated);
 
-			string description = $"Sell price:\t${gbn}{sellingPrice}~w~\n" +
-				$"Average price:\t${averagePrice}\n" +
-				$"Total price:\t${gbn}{totalPrice}";
+    /// <summary>
+    /// Sets all possible things for the <paramref name="item"/> itself.
+    /// </summary>
+    /// <param name="item">The item to refresh.</param>
+    /// <param name="drug">The drug instance to use.</param>
+    private void SetDrugListItem(NativeListItem<int> item, IDrug drug)
+    {
+        // Properly unsubscribe previous handler for this item, if any.
+        if (_itemChangedHandlers.TryGetValue(item, out var oldHandler))
+        {
+            item.ItemChanged -= oldHandler;
+            _itemChangedHandlers.Remove(item);
+        }
 
-			item.Description = description;
-		}
+        item.Enabled = drug.Quantity > 0;
+        item.Tag = drug;
 
-		if (Type is TransactionType.SELL)
-		{
-			int sellingPrice = _target.Where(x => x.Type.Equals(drug.Type)).Select(x => x.Price).First();
-			int purchasePrice = drug.Price;
-			int currentQuantitity = item.SelectedItem;
-			int totalPrice = sellingPrice * currentQuantitity;
-			string gbn = GoodBadNetral(purchasePrice, sellingPrice);
+        // Rebuild items (0..Quantity) and clamp the selected index.
+        item.Items = drug.Quantity.GetList();
+        item.SelectedIndex = item.Items.Count > 0 ? Math.Min(drug.Quantity, item.Items.Count - 1) : 0;
 
-			string description = $"Sell price:\t${gbn}{sellingPrice}~w~\n" +
-				$"Bought price:\t${purchasePrice}\n" +
-				$"Total price:\t${gbn}{totalPrice}";
+        // Attach stable handler that passes the sender back.
+        ItemChangedEventHandler<int> handler = (sender, args) => OnItemChanged(sender);
+        item.ItemChanged += handler;
+        _itemChangedHandlers[item] = handler;
 
-			item.Description = description;
-		}
-	}
+        SetItemDescription(item);
+    }
 
-	/// <summary>
-	/// Compares to values with each other.
-	/// </summary>
-	/// <param name="valueOne">The first vlaue.</param>
-	/// <param name="valueTwo">The second value.</param>
-	/// <returns>The good, bad or neutral string.</returns>
-	private static string GoodBadNetral(int valueOne, int valueTwo)
-		=> valueOne <= valueTwo ? valueOne < valueTwo ? "~g~" : "~w~" : "~r~";
+    /// <summary>
+    /// Sets the item description depending on the Tag and TransactionType.
+    /// </summary>
+    private void SetItemDescription(NativeListItem<int> item)
+    {
+        if (item.Tag is not IDrug drug || drug.Quantity == 0)
+        {
+            item.Description = "~w~No stock available.";
+            return;
+        }
 
-	/// <summary>
-	/// Returns the menu offset.
-	/// </summary>
-	private PointF GetMenuOffset()
-	{
-		Size screenSize = _providerManager.ScreenProvider.Resolution;
-		return new PointF(screenSize.Width / 64, screenSize.Height / 36);
-	}
+        int qty = Math.Max(0, item.SelectedItem);
+
+        if (Type is TransactionType.BUY)
+        {
+            // Player buys FROM the source, so this is a "Buy price".
+            int buyPrice = drug.Price;
+            int average = drug.Type.GetAveragePrice();
+            int total = buyPrice * qty;
+            string gbn = GoodBadNetral(buyPrice, average);
+
+            item.Description =
+                $"Buy price:\t${gbn}{FormatMoney(buyPrice)}~w~\n" +
+                $"Average:\t${FormatMoney(average)}\n" +
+                $"Total:\t\t${gbn}{FormatMoney(total)}";
+            return;
+        }
+
+        if (Type is TransactionType.SELL)
+        {
+            // Player sells TO the target (dealer’s buying price).
+            int targetPrice = _target.FirstOrDefault(x => x.Type.Equals(drug.Type))?.Price ?? drug.Price;
+            int purchasePrice = drug.Price;
+            int total = targetPrice * qty;
+            string gbn = GoodBadNetral(purchasePrice, targetPrice);
+
+            item.Description =
+                $"Sell price:\t${gbn}{FormatMoney(targetPrice)}~w~\n" +
+                $"Bought price:\t${FormatMoney(purchasePrice)}\n" +
+                $"Total:\t\t${gbn}{FormatMoney(total)}";
+            return;
+        }
+
+        // Fallback for other transaction types
+        item.Description = $"~w~Qty: {qty}  Price: ${FormatMoney(drug.Price)}";
+    }
+
+    /// <summary>
+    /// Compares two values and returns a GTA color code (green/white/red).
+    /// </summary>
+    private static string GoodBadNetral(int valueOne, int valueTwo) => GoodBadNeutral(valueOne, valueTwo);
+
+    private static string GoodBadNeutral(int valueOne, int valueTwo)
+    {
+        if (valueOne < valueTwo) return "~g~";
+        if (valueOne == valueTwo) return "~w~";
+        return "~r~";
+    }
+
+    private static string FormatMoney(int value) => value.ToString("N0");
+
+    /// <summary>
+    /// Returns the menu offset.
+    /// </summary>
+    private PointF GetMenuOffset()
+    {
+        Size screenSize = _providerManager.ScreenProvider.Resolution;
+        return new PointF(screenSize.Width / 64f, screenSize.Height / 36f);
+    }
 }


### PR DESCRIPTION
Correct event unsubscribe & memory-leak prevention

Previously, item.ItemChanged -= (sender, args) => OnItemChanged(item); created a new delegate on unsubscribe, which doesn’t match the one originally added, so the old handler stayed attached.

Added a _itemChangedHandlers dictionary to keep strong references to the exact delegates. We now properly detach/re-attach handlers when rebuilding items to avoid duplicate callbacks and leaks.

Robust selection/index handling

Ensured SelectedIndex is clamped to the available range (0..Items.Count-1) after rebuilding Items, avoiding out-of-range errors when quantities change.

Early-return when quantity is zero and show ~w~No stock available.

Clearer pricing UI & correct semantics

BUY branch now labels as “Buy price” (player buys from source), and SELL branch uses the target inventory price if available (safe fallback to current drug price).

Prices are displayed with thousands separators via ToString("N0").

Introduced FormatMoney helper for consistent formatting.

Stability and nullability

Enabled nullable reference types (#nullable enable) to surface potential null issues during compilation.

Defensive checks in OnItemActivated (ignore zero-quantity actions).

Correct color indicator logic reuse

Kept original GoodBadNetral method name for compatibility but routed it to a new, correctly spelled GoodBadNeutral method, improving readability without breaking callers.

Feedback on transaction failures

If _transactionService.Commit(...) returns false, we prepend an error note to the item description to give immediate user feedback.

Minor polish

Slight float literals for GetMenuOffset() divisions to avoid integer truncation.

Explicit using System.Linq; and using System; to support LINQ queries and events.

Safer computation of quantities (Math.Max(0, item.SelectedItem)).

These changes make the menu more reliable, clearer to use, and safer under changing inventories, while keeping existing public behavior and signatures intact.